### PR TITLE
changed 'paystack' to 'ravpay'

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Usage:
 pip install -e git+https://github.com/gbozee/django-ravepay.git@master#egg=ravepay
 ```
 
-2. Add `paystack` to your `settings` module
+2. Add `ravpay` to your `settings` module
 ```
 INSTALLED_APPS = [
     ...,


### PR DESCRIPTION
A mistake was made in the explanation for adding the app in list of installed apps. 'paystack' was used instead of 'ravpay'